### PR TITLE
[CEN-1418] Add test to ensure BPD payment instruments are not exposed

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,3 @@ Please intall them before running any test suite.
 9. Customize env variables in `./test/e2e/prod/.env.production.local` [`./test/e2e/uat/.env.test.local`]
 10. Run the following test in prod [uat]
 ```./k6  run test/e2e/prod/bpdHbAwardPeriod.js [./k6  run test/e2e/uat/bpdHbAwardPeriod.js]```
-

--- a/smoke_env.sh
+++ b/smoke_env.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# Quickly perform a smoke test on target environment by running each
+# test found under test/e2e/<ENV> once.
+
+E2E_DIR="test/e2e"
+K6_BINARY="k6"
+K6_TEST_FILEEXT=".js"
+
+set -e
+
+ENV=$1
+
+if [ -z "$ENV" ]; then
+  echo "ENV should be: dev, uat or prod."
+  exit 0
+fi
+
+for TEST in $(ls test/e2e/$ENV/*$K6_TEST_FILEEXT); do
+	./$K6_BINARY run $TEST
+done;

--- a/test/e2e/dev/bpdTermsAndConditions.js
+++ b/test/e2e/dev/bpdTermsAndConditions.js
@@ -1,8 +1,7 @@
 import { group } from 'k6';
 import {
   GetBpdTermsAndConditionsViaBlob,
-  GetBpdTermsAndConditions,
-  GetBpdPrivacyPolicy
+  GetBpdTermsAndConditions
 } from '../../tests/bpdHbTermsAndConditions.js';
 import dotenv from 'k6/x/dotenv';
 
@@ -35,6 +34,5 @@ export default () => {
 
     group('Should get BPD T&C via Blob Get', () => GetBpdTermsAndConditionsViaBlob(services.dev_issuer.baseUrl, params));
     group('Should get BPD T&C via dedicated API', () => GetBpdTermsAndConditions(services.dev_issuer.baseUrl, params));
-
   });
 }

--- a/test/e2e/dev/env.development.local.sample
+++ b/test/e2e/dev/env.development.local.sample
@@ -1,5 +1,9 @@
 APIM_SK=[your subscription key]
+APIM_RTDPRODUCT_SK=[subscription key under product RTD_API_Product]
 MAUTH_CERT_NAME=[name of the mauth certificate file in certs directory]
 MAUTH_PRIVATE_KEY_NAME=[name of the mauth rivate key file in certs directory ]
 PAN_OK=[pan of a card enrolled]
 FISCAL_CODE_EXISTING=[fiscal code]
+
+# Max content length for /hashed-pans API in bytes (0 means no max length)
+RTD_HASHPAN_MAX_CONTENT_LENGTH=0

--- a/test/e2e/dev/rtdCsvTransaction.js
+++ b/test/e2e/dev/rtdCsvTransaction.js
@@ -22,7 +22,7 @@ export default () => {
   group('CSV Transaction API', () => {
     let params = {
       headers: {
-        'Ocp-Apim-Subscription-Key': `${myEnv.APIM_SK}`,
+        'Ocp-Apim-Subscription-Key': myEnv.APIM_RTDPRODUCT_SK,
         'Ocp-Apim-Trace': 'true'
       }
     }

--- a/test/e2e/dev/rtdCsvTransactionDecrypted.js
+++ b/test/e2e/dev/rtdCsvTransactionDecrypted.js
@@ -22,7 +22,7 @@ export default () => {
   group('CSV Transaction Decrypted API', () => {
     let params = {
       headers: {
-        'Ocp-Apim-Subscription-Key': `${myEnv.APIM_SK}`,
+        'Ocp-Apim-Subscription-Key': myEnv.APIM_RTDPRODUCT_SK,
         'Ocp-Apim-Trace': 'true'
       }
     }

--- a/test/e2e/dev/rtdPaymentInstrumentManager.js
+++ b/test/e2e/dev/rtdPaymentInstrumentManager.js
@@ -22,12 +22,16 @@ export default () => {
   group('Payment Instrument API', () => {
     let params = {
       headers: {
-        'Ocp-Apim-Subscription-Key': `${myEnv.APIM_SK}`,
+        'Ocp-Apim-Subscription-Key': myEnv.APIM_RTDPRODUCT_SK,
         'Ocp-Apim-Trace': 'true'
       }
     }
 
-    group('Should get hashed pans', () => GetHashedPan(services.dev_issuer.baseUrl, params));
+    let getHashedPanOpts = {
+      maxContentLength: myEnv.RTD_HASHPAN_MAX_CONTENT_LENGTH
+    }
+    group('Should get hashed pans', () => GetHashedPan(services.dev_issuer.baseUrl, params, getHashedPanOpts));
+
     group('Should get salt', () => GetSalt(services.dev_issuer.baseUrl, params));
 
   })

--- a/test/e2e/prod/env.production.local.sample
+++ b/test/e2e/prod/env.production.local.sample
@@ -1,4 +1,9 @@
 APIM_SK=[your subscription key]
+APIM_RTDPRODUCT_SK=[subscription key under product RTD_API_Product]
 MAUTH_CERT_NAME=[name of the mauth certificate file in certs directory]
 MAUTH_PRIVATE_KEY_NAME=[name of the mauth rivate key file in certs directory ]
 PAN_OK=[pan of a card enrolled]
+FISCAL_CODE_EXISTING=[fiscal code]
+
+# Max content length for /hashed-pans API in bytes (0 means no max length)
+RTD_HASHPAN_MAX_CONTENT_LENGTH=0

--- a/test/e2e/uat/env.test.local.sample
+++ b/test/e2e/uat/env.test.local.sample
@@ -1,5 +1,9 @@
 APIM_SK=[your subscription key]
+APIM_RTDPRODUCT_SK=[subscription key under product RTD_API_Product]
 MAUTH_CERT_NAME=[name of the mauth certificate file in certs directory]
 MAUTH_PRIVATE_KEY_NAME=[name of the mauth rivate key file in certs directory ]
 PAN_OK=[pan of a card enrolled]
 FISCAL_CODE_EXISTING=[fiscal code]
+
+# Max content length for /hashed-pans API in bytes (0 means no max length)
+RTD_HASHPAN_MAX_CONTENT_LENGTH=0

--- a/test/e2e/uat/rtdPaymentInstrumentManager.js
+++ b/test/e2e/uat/rtdPaymentInstrumentManager.js
@@ -6,12 +6,12 @@ export let options = {};
 export let services = JSON.parse(open('../../../services/environments.json'));
 
 // open is only available in global scope
-const myEnv = dotenv.parse(open(".env.production.local"));
+const myEnv = dotenv.parse(open(".env.test.local"));
 
 // patch options
 options.tlsAuth = [
   {
-    domains: [services.prod_issuer.baseUrl],
+    domains: [services.uat_issuer.baseUrl],
     cert: open(`../../../certs/${myEnv.MAUTH_CERT_NAME}`),
     key: open(`../../../certs/${myEnv.MAUTH_PRIVATE_KEY_NAME}`),
   }
@@ -30,9 +30,8 @@ export default () => {
     let getHashedPanOpts = {
       maxContentLength: myEnv.RTD_HASHPAN_MAX_CONTENT_LENGTH
     }
-    group('Should get hashed pans', () => GetHashedPan(services.prod_issuer.baseUrl, params, getHashedPanOpts));
-
-    group('Should get salt', () => GetSalt(services.prod_issuer.baseUrl, params));
+    group('Should get hashed pans', () => GetHashedPan(services.uat_issuer.baseUrl, params, getHashedPanOpts));
+    group('Should get salt', () => GetSalt(services.uat_issuer.baseUrl, params));
 
   })
 }

--- a/test/tests/bpdHbTermsAndConditions.js
+++ b/test/tests/bpdHbTermsAndConditions.js
@@ -1,17 +1,14 @@
 import http from 'k6/http';
-import { check } from 'k6';
+import { CheckStatusConflict, CheckStatusOk } from './common.js';
 
 export function GetBpdTermsAndConditionsViaBlob(baseUrl, params) {
 
   const res = http.get(
     `${baseUrl}/pagopastorage/bpd-terms-and-conditions/bpd-tc.html`,
     params
-  );
+  )
 
-  const isSuccessful = check(res, { 'Success': (r) => r.status === 200 });
-  if (!isSuccessful) {
-    console.log(`Attempted ${res.headers['Ocp-Apim-Operationid']}. Unsuccessful. Response status ${res.status}. Please check trace ${res.headers['Ocp-Apim-Trace-Location']}`)
-  }
+  CheckStatusConflict(res);
 }
 
 export function GetBpdTermsAndConditions(baseUrl, params) {
@@ -21,22 +18,5 @@ export function GetBpdTermsAndConditions(baseUrl, params) {
     params
   );
 
-  const isSuccessful = check(res, { 'Success': (r) => r.status === 200 });
-  if (!isSuccessful) {
-    console.log(`Attempted ${res.headers['Ocp-Apim-Operationid']}. Unsuccessful. Response status ${res.status}. Please check trace ${res.headers['Ocp-Apim-Trace-Location']}`)
-  }
-}
-
-// Fails. Info privacy file is not uploaded in the blob storage
-export function GetBpdPrivacyPolicy(baseUrl, params) {
-
-  const res = http.get(
-    `${baseUrl}/cstar-bpd/info-privacy`,
-    params
-  );
-
-  const isSuccessful = check(res, { 'Success': (r) => r.status === 200 });
-  if (!isSuccessful) {
-    console.log(`Attempted ${res.headers['Ocp-Apim-Operationid']}. Unsuccessful. Response status ${res.status}. Please check trace ${res.headers['Ocp-Apim-Trace-Location']}`)
-  }
+  CheckStatusOk(res);
 }

--- a/test/tests/common.js
+++ b/test/tests/common.js
@@ -1,0 +1,52 @@
+import { check } from 'k6';
+
+export function CheckStatusOk(res) {
+  const isOk = check(res, { 'HTTP status is 200': (r) => r.status === 200 });
+  if (!isOk) {
+    console.log(`Attempted ${res.headers['Ocp-Apim-Operationid']}. Unsuccessful. Response status ${res.status}. Please check trace ${res.headers['Ocp-Apim-Trace-Location']}`);
+  }
+}
+
+export function CheckStatusCreated(res) {
+  const isOk = check(res, { 'HTTP status is 201': (r) => r.status === 201 });
+  if (!isOk) {
+    console.log(`Attempted ${res.headers['Ocp-Apim-Operationid']}. Unsuccessful. Response status ${res.status}. Please check trace ${res.headers['Ocp-Apim-Trace-Location']}`);
+  }
+}
+
+export function CheckStatusForbidden(res) {
+  const isOk = check(res, { 'HTTP status is 401': (r) => r.status === 401 });
+  if (!isOk) {
+    console.log(`Attempted ${res.headers['Ocp-Apim-Operationid']}. Unsuccessful. Response status ${res.status}. Please check trace ${res.headers['Ocp-Apim-Trace-Location']}`);
+  }
+}
+
+export function CheckStatusConflict(res) {
+  const isOk = check(res, { 'HTTP status is 409': (r) => r.status === 409 });
+  if (!isOk) {
+    console.log(`Attempted ${res.headers['Ocp-Apim-Operationid']}. Unsuccessful. Response status ${res.status}. Please check trace ${res.headers['Ocp-Apim-Trace-Location']}`);
+  }
+}
+
+export function CheckBodyLengthBetween(res, minLength, maxLength) {
+  if (minLength > 0) {
+    const isOk = check(res, {
+      'body size is more than or equal to minLength': (r) => r.body.length >= minLength
+    });
+    if (!isOk) {
+      console.log(`Response body length was ${res.body.length} (min ${maxLength})`);
+    }
+  }
+  if (maxLength > 0) {
+    const isOk = check(res, {
+      'body size is less than or equal to maxLength': (r) => r.body.length <= maxLength
+    });
+    if (!isOk) {
+      console.log(`Response body length was ${res.body.length} (max ${maxLength})`);
+    }
+  }
+}
+
+export function CheckBodyPgpPublicKey(res) {
+  check(res, { 'Response body contains PGP public key header': (r) => r.body.includes('-----BEGIN PGP PUBLIC KEY BLOCK-----') });
+}

--- a/test/tests/faHbTermsAndConditions.js
+++ b/test/tests/faHbTermsAndConditions.js
@@ -1,17 +1,14 @@
 import http from 'k6/http';
-import { check } from 'k6';
+import { CheckStatusConflict, CheckStatusOk } from './common.js';
 
 export function GetFaTermsAndConditionsViaBlob(baseUrl, params) {
 
   const res = http.get(
     `${baseUrl}/pagopastorage/fa-terms-and-conditions/fa-tc.html`,
     params
-  );
+  )
 
-  const isSuccessful = check(res, { 'Success': (r) => r.status === 200 });
-  if (!isSuccessful) {
-    console.log(`Attempted ${res.headers['Ocp-Apim-Operationid']}. Unsuccessful. Response status ${res.status}. Please check trace ${res.headers['Ocp-Apim-Trace-Location']}`)
-  }
+  CheckStatusConflict(res);
 }
 
 export function GetFaTermsAndConditions(baseUrl, params) {
@@ -21,8 +18,5 @@ export function GetFaTermsAndConditions(baseUrl, params) {
     params
   );
 
-  const isSuccessful = check(res, { 'Success': (r) => r.status === 200 });
-  if (!isSuccessful) {
-    console.log(`Attempted ${res.headers['Ocp-Apim-Operationid']}. Unsuccessful. Response status ${res.status}. Please check trace ${res.headers['Ocp-Apim-Trace-Location']}`)
-  }
+  CheckStatusOk(res);
 }

--- a/test/tests/rtdCsvTransaction.js
+++ b/test/tests/rtdCsvTransaction.js
@@ -1,44 +1,37 @@
 import http from 'k6/http';
-import { check } from 'k6';
+import { CheckStatusOk, CheckStatusCreated, CheckBodyPgpPublicKey } from './common.js';
+
+const API_PREFIX = '/rtd/csv-transaction';
 
 export function GetPublicKey(baseUrl, params ) {
 
   const res = http.get(
-    `${baseUrl}/rtd/csv-transaction/publickey`,
+    `${baseUrl}${API_PREFIX}/publickey`,
     params
-  );
+  )
 
-  const isSuccessful = check(res, { 'Success': (r) => r.status === 200 });
-  const isBodyPgpPublicKey = check(res, { 'Success': (r) => r.body.includes('-----BEGIN PGP PUBLIC KEY BLOCK-----') });
-  if (!isSuccessful) {
-    console.log(`Attempted ${res.headers['Ocp-Apim-Operationid']}. Unsuccessful. Response status ${res.status}. Please check trace ${res.headers['Ocp-Apim-Trace-Location']}`);
-  }
+  CheckStatusOk(res);
+  CheckBodyPgpPublicKey(res);
 }
 
 export function GetAdeSas(baseUrl, params ) {
 
   const res = http.post(
-    `${baseUrl}/rtd/csv-transaction/ade/sas`,
+    `${baseUrl}${API_PREFIX}/ade/sas`,
 	{}, // Empty payload
     params
-  );
+  )
 
-  const isSuccessful = check(res, { 'Success': (r) => r.status === 201 });
-  if (!isSuccessful) {
-    console.log(`Attempted ${res.headers['Ocp-Apim-Operationid']}. Unsuccessful. Response status ${res.status}. Please check trace ${res.headers['Ocp-Apim-Trace-Location']}`);
-  }
+  CheckStatusCreated(res);
 }
 
 export function GetRtdSas(baseUrl, params ) {
 
   const res = http.post(
-    `${baseUrl}/rtd/csv-transaction/rtd/sas`,
+    `${baseUrl}${API_PREFIX}/rtd/sas`,
 	{}, // Empty payload
     params
-  );
+  )
 
-  const isSuccessful = check(res, { 'Success': (r) => r.status === 201 });
-  if (!isSuccessful) {
-    console.log(`Attempted ${res.headers['Ocp-Apim-Operationid']}. Unsuccessful. Response status ${res.status}. Please check trace ${res.headers['Ocp-Apim-Trace-Location']}`);
-  }
+  CheckStatusCreated(res);
 }

--- a/test/tests/rtdCsvTransactionDecrypted.js
+++ b/test/tests/rtdCsvTransactionDecrypted.js
@@ -1,10 +1,12 @@
 import http from 'k6/http';
 import { CheckStatusForbidden } from './common.js';
 
+const API_PREFIX = '/rtd/csv-transaction-decrypted';
+
 export function GetAdeSas(baseUrl, params ) {
 
   const res = http.post(
-    `${baseUrl}/rtd/csv-transaction-decrypted/ade/sas`,
+    `${baseUrl}${API_PREFIX}/ade/sas`,
 	{}, // Empty payload
     params
   )
@@ -15,7 +17,7 @@ export function GetAdeSas(baseUrl, params ) {
 export function GetRtdSas(baseUrl, params ) {
 
   const res = http.post(
-    `${baseUrl}/rtd/csv-transaction-decrypted/rtd/sas`,
+    `${baseUrl}${API_PREFIX}/rtd/sas`,
 	{}, // Empty payload
     params
   );

--- a/test/tests/rtdCsvTransactionDecrypted.js
+++ b/test/tests/rtdCsvTransactionDecrypted.js
@@ -1,5 +1,5 @@
 import http from 'k6/http';
-import { check } from 'k6';
+import { CheckStatusForbidden } from './common.js';
 
 export function GetAdeSas(baseUrl, params ) {
 
@@ -7,9 +7,9 @@ export function GetAdeSas(baseUrl, params ) {
     `${baseUrl}/rtd/csv-transaction-decrypted/ade/sas`,
 	{}, // Empty payload
     params
-  );
+  )
 
-  check(res, { 'Forbidden': (r) => r.status === 403 });
+  CheckStatusForbidden(res);
 }
 
 export function GetRtdSas(baseUrl, params ) {
@@ -20,5 +20,5 @@ export function GetRtdSas(baseUrl, params ) {
     params
   );
 
-  check(res, { 'Forbidden': (r) => r.status === 403 });
+  CheckStatusForbidden(res);
 }

--- a/test/tests/rtdPaymentInstrumentManager.js
+++ b/test/tests/rtdPaymentInstrumentManager.js
@@ -1,28 +1,25 @@
 import http from 'k6/http';
-import { check } from 'k6';
+import { CheckStatusOk, CheckBodyLengthBetween } from './common.js';
 
-export function GetHashedPan(baseUrl, params ) {
+const API_PREFIX = '/rtd/payment-instrument-manager';
+
+export function GetHashedPan(baseUrl, params, opts) {
 
   const res = http.get(
-    `${baseUrl}/rtd/payment-instrument-manager/hashed-pans`,
+    `${baseUrl}${API_PREFIX}/hashed-pans`,
     params
   );
 
-  const isSuccessful = check(res, { 'Success': (r) => r.status === 200 });
-  if (!isSuccessful) {
-    console.log(`Attempted ${res.headers['Ocp-Apim-Operationid']}. Unsuccessful. Response status ${res.status}. Please check trace ${res.headers['Ocp-Apim-Trace-Location']}`);
-  }
+  CheckStatusOk(res);
+  CheckBodyLengthBetween(res, 0, opts.maxContentLength);
 }
 
-export function GetSalt(baseUrl, params ) {
+export function GetSalt(baseUrl, params) {
 
   const res = http.get(
-    `${baseUrl}/rtd/payment-instrument-manager/salt`,
+    `${baseUrl}${API_PREFIX}/salt`,
     params
   );
 
-  const isSuccessful = check(res, { 'Success': (r) => r.status === 200 });
-  if (!isSuccessful) {
-    console.log(`Attempted ${res.headers['Ocp-Apim-Operationid']}. Unsuccessful. Response status ${res.status}. Please check trace ${res.headers['Ocp-Apim-Trace-Location']}`);
-  }
+  CheckStatusOk(res);
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR adds tests to verify that payment instruments enrolled on BPD are not exposed anymore through the /hashed-pans API.

It also refactor some tests in order to reduce boilerplate / code duplication, and adds a little script to automate the smoke testing of a single environment.

### List of changes

<!--- Describe your changes in detail -->
- new test verifying the correct execution or CEN-1418
- new script smoke_env.sh to quickly assess the health of a single target environment
- minor refactoring

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This PR automates the verification of the CEN-1418 (do not expose anymore payment instruments enrolled on BPD).

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->


- [x] Test case
- [x] Test suite

### Affected environment

- [x] Development (DEV)
- [x] User Acceptance / Third Part Integration (UAT)
- [x] Production (PROD)

### Test type

- [x] End to end
- [ ] Performance
- [x] Smoke test

### Type of changes

- [x] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->