### PR TITLE
[CEN-1437] Add script to run load tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 certs
 k6
+k6.*
 .env*
 .env.development.local
 .env.test.local

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ test
 ./smoke_env.sh <ENV>
 ```
 
+### Perform the whole suite of load tests on a target environment
+
+```
+./load_env.sh <ENV>
+```
+
 ### Enable HTTP tracing
 
 With tracing enabled all HTTP responses will be printed to standard output.

--- a/load_env.sh
+++ b/load_env.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# Quickly perform a smoke test on target environment by running each
-# test found under test/smoke once.
+# Quickly perform a load tests on target environment by running each
+# test found under test/performance once.
 #
-# Usage: ./smoke_env.sh <dev|uat|prod>
+# Usage: ./load_env.sh <dev|uat|prod>
 
 
 TESTS_DIR="test/performance"
@@ -15,7 +15,7 @@ set -e
 ENV=$1
 
 if [[ -z "$ENV" || ! "$ENV" =~ ^(dev|uat|prod)$ ]]; then
-  echo "Usage: ./smoke_env.sh <dev|uat|prod>"
+  echo "Usage: ./load_env.sh <dev|uat|prod>"
   exit 0
 fi
 

--- a/load_env.sh
+++ b/load_env.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Quickly perform a smoke test on target environment by running each
+# test found under test/smoke once.
+#
+# Usage: ./smoke_env.sh <dev|uat|prod>
+
+
+TESTS_DIR="test/performance"
+K6_BINARY="k6"
+K6_TEST_FILEEXT=".js"
+
+set -e
+
+ENV=$1
+
+if [[ -z "$ENV" || ! "$ENV" =~ ^(dev|uat|prod)$ ]]; then
+  echo "Usage: ./smoke_env.sh <dev|uat|prod>"
+  exit 0
+fi
+
+for TEST in $(ls $TESTS_DIR/*$K6_TEST_FILEEXT); do
+	TARGET_ENV=$ENV ./$K6_BINARY run $TEST
+done;


### PR DESCRIPTION
This pull request adds a bash script (similar to the one for smoke tests) that allows to run load tests (this will be needed in the future, when there will be more of them). In addition, a line has been added to gitignore to allow ignoring any "k6" executables with an extension (e.g. Windows executables with .exe extension).

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->


- [ ] Test case
- [ ] Test suite

### Affected environment

- [ ] Development (DEV)
- [ ] User Acceptance / Third Part Integration (UAT)
- [ ] Production (PROD)

### Test type

- [ ] End to end
- [x] Performance
- [ ] Smoke test

### Type of changes

- [ ] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [ ] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->