### PR TITLE
Cen 851 add load tests fa hb customer

### DIFF
--- a/services/environments.json
+++ b/services/environments.json
@@ -16,5 +16,11 @@
   },
   "prod_issuer": {
     "baseUrl": "https://api.cstar.pagopa.it"
+  },
+  "uat_issuer_internal": {
+    "baseUrl": "http://10.1.0.250"
+  },
+  "dev_issuer_internal": {
+    "baseUrl": "http://10.1.0.250"
   }
 }

--- a/test/common/api/faHbCustomer.js
+++ b/test/common/api/faHbCustomer.js
@@ -1,0 +1,26 @@
+import http from 'k6/http'
+
+const API_PREFIX = '/fa/hb/customer'
+
+export function getFaCustomer(baseUrl, params, id, xRequestId) {
+    const myParams = Object.assign({}, params)
+    myParams.headers.id = id
+    if (xRequestId) {
+        myParams.headers['x-request-id'] = xRequestId
+    }
+    const res = http.get(`${baseUrl}${API_PREFIX}`, myParams)
+    __ENV.REQ_DUMP === undefined || console.log(JSON.stringify(res, null, 2))
+    return res
+}
+
+export function putFaCustomer(baseUrl, params, body) {
+    const myParams = Object.assign({}, params)
+    const res = http.put(
+        `${baseUrl}${API_PREFIX}`,
+        JSON.stringify(body),
+        myParams
+    )
+    console.log(JSON.stringify(res))
+    __ENV.REQ_DUMP === undefined || console.log(JSON.stringify(res, null, 2))
+    return res
+}

--- a/test/common/api/faHbCustomer.js
+++ b/test/common/api/faHbCustomer.js
@@ -20,7 +20,6 @@ export function putFaCustomer(baseUrl, params, body) {
         JSON.stringify(body),
         myParams
     )
-    console.log(JSON.stringify(res))
     __ENV.REQ_DUMP === undefined || console.log(JSON.stringify(res, null, 2))
     return res
 }

--- a/test/common/api/faHbCustomer.js
+++ b/test/common/api/faHbCustomer.js
@@ -23,3 +23,26 @@ export function putFaCustomer(baseUrl, params, body) {
     __ENV.REQ_DUMP === undefined || console.log(JSON.stringify(res, null, 2))
     return res
 }
+
+export function getFaCustomerInternal(baseUrl, params, id) {
+    const myParams = Object.assign({}, params)
+    const apiPrefix = '/famscustomer/fa/customer'
+    const url = `${baseUrl}${apiPrefix}/${id}`
+    myParams.headers.id = id
+    const res = http.get(url, myParams)
+    __ENV.REQ_DUMP === undefined || console.log(JSON.stringify(res, null, 2))
+    return res
+}
+
+export function putFaCustomerInternal(baseUrl, params, body) {
+    const myParams = Object.assign({}, params)
+    const apiPrefix = '/famsenrollment/fa/enrollment/customer'
+    const url = `${baseUrl}${apiPrefix}/${body.id}`
+    const res = http.put(
+        url,
+        JSON.stringify(body),
+        myParams
+    )
+    __ENV.REQ_DUMP === undefined || console.log(JSON.stringify(res, null, 2))
+    return res
+}

--- a/test/common/utils.js
+++ b/test/common/utils.js
@@ -1,0 +1,12 @@
+import { randomString } from "https://jslib.k6.io/k6-utils/1.1.0/index.js"
+
+export function randomFiscalCode() {
+	"^([A-Za-z]{6}[0-9lmnpqrstuvLMNPQRSTUV]{2}[abcdehlmprstABCDEHLMPRST]{1}[0-9lmnpqrstuvLMNPQRSTUV]{2}[A-Za-z]{1}[0-9lmnpqrstuvLMNPQRSTUV]{3}[A-Za-z]{1})$"
+  
+	const name = randomString(6);
+	const birth_y = (40 + (Math.floor(Math.random() * 50))).toString();
+	const birth_m = "M"
+	const birth_d = Math.floor(Math.random() * 30).toString()
+	const final = [randomString(1), (100 + Math.floor(Math.random() * 899)).toString(), randomString(1)].join("");
+	return [name, birth_y, birth_m, birth_d, final].join("");
+}

--- a/test/performance/faHbCustomer.js
+++ b/test/performance/faHbCustomer.js
@@ -4,7 +4,7 @@ import { getFaCustomer, putFaCustomer } from '../common/api/faHbCustomer.js'
 import { assert, statusOk } from '../common/assertions.js'
 import { isEnvValid, isTestEnabledOnEnv, DEV, UAT } from '../common/envs.js'
 import dotenv from 'k6/x/dotenv'
-import { randomString } from "https://jslib.k6.io/k6-utils/1.1.0/index.js"
+import { randomFiscalCode } from '../common/utils.js'
 
 const REGISTERED_ENVS = [DEV, UAT]
 
@@ -52,18 +52,6 @@ if (isEnvValid(__ENV.TARGET_ENV)) {
 if (!isTestEnabledOnEnv(__ENV.TARGET_ENV, REGISTERED_ENVS)) {
 	console.log('Test not enabled for target env')
 	exec.test.abort()
-}
-
-
-function randomFiscalCode() {
-	"^([A-Za-z]{6}[0-9lmnpqrstuvLMNPQRSTUV]{2}[abcdehlmprstABCDEHLMPRST]{1}[0-9lmnpqrstuvLMNPQRSTUV]{2}[A-Za-z]{1}[0-9lmnpqrstuvLMNPQRSTUV]{3}[A-Za-z]{1})$"
-  
-	const name = randomString(6);
-	const birth_y = (40 + (Math.floor(Math.random() * 50))).toString();
-	const birth_m = "M"
-	const birth_d = Math.floor(Math.random() * 30).toString()
-	const final = [randomString(1), (100 + Math.floor(Math.random() * 899)).toString(), randomString(1)].join("");
-	return [name, birth_y, birth_m, birth_d, final].join("");
 }
 
 

--- a/test/performance/faHbCustomer.js
+++ b/test/performance/faHbCustomer.js
@@ -1,0 +1,54 @@
+import { group } from 'k6'
+import exec from 'k6/execution'
+import { putFaCustomer } from '../common/api/faHbCustomer.js'
+import { assert, statusCreated } from '../common/assertions.js'
+import { isEnvValid, isTestEnabledOnEnv, DEV, UAT } from '../common/envs.js'
+import dotenv from 'k6/x/dotenv'
+
+const REGISTERED_ENVS = [DEV, UAT]
+
+const services = JSON.parse(open('../../services/environments.json'))
+export let options = JSON.parse(open('../../options/baseline_load.json'))
+let params = {}
+let baseUrl
+let myEnv
+
+if (isEnvValid(__ENV.TARGET_ENV)) {
+	myEnv = dotenv.parse(open(`../../.env.${__ENV.TARGET_ENV}.local`))
+	baseUrl = services[`${__ENV.TARGET_ENV}_issuer`].baseUrl
+
+	options.tlsAuth = [
+		{
+			domains: [baseUrl],
+			cert: open(`../../certs/${myEnv.MAUTH_CERT_NAME}`),
+			key: open(`../../certs/${myEnv.MAUTH_PRIVATE_KEY_NAME}`),
+		},
+	]
+
+	params.headers = {
+		'Ocp-Apim-Subscription-Key': myEnv.APIM_SK,
+		'Ocp-Apim-Trace': 'true',
+        'Content-Type': 'application/json'
+	}
+}
+
+// In performance tests we shall use abort() to prevent the execution
+// of the default function, otherwise the VUs will be spawned
+if (!isTestEnabledOnEnv(__ENV.TARGET_ENV, REGISTERED_ENVS)) {
+	console.log('Test not enabled for target env')
+	exec.test.abort()
+}
+
+const body = {
+    vatNumber: '1234567'
+}
+
+export default () => {
+	group('FA HB Customer API', () => {
+		group('Should create an FA CUSTOMER', () =>
+			assert(putFaCustomer(services.dev_issuer.baseUrl, params, body), [
+				statusCreated(),
+			])
+		)
+	})
+}

--- a/test/performance/internal/faHbCustomer.js
+++ b/test/performance/internal/faHbCustomer.js
@@ -1,0 +1,78 @@
+import { group } from 'k6'
+import exec from 'k6/execution'
+import { getFaCustomerInternal, putFaCustomerInternal } from '../../common/api/faHbCustomer.js'
+import { assert, statusOk } from '../../common/assertions.js'
+import { isEnvValid, isTestEnabledOnEnv, DEV, UAT } from '../../common/envs.js'
+import dotenv from 'k6/x/dotenv'
+import { randomFiscalCode } from '../../common/utils.js'
+
+const REGISTERED_ENVS = [DEV, UAT]
+
+const services = JSON.parse(open('../../../services/environments.json'))
+
+export let options = {
+	scenarios: {
+		constant_request_rate: {
+		  executor: 'constant-arrival-rate',
+		  rate: 1,
+		  timeUnit: '1s',
+		  duration: '1m',
+		  preAllocatedVUs: 100,
+		  maxVUs: 10000,
+		},
+	},
+	summaryTrendStats: ['med', 'avg', 'min', 'max', 'p(10)', "p(20)", 'p(30)', 'p(40)', 'p(50)', 'p(60)', 'p(70)', 'p(80)', 'p(90)'],
+}
+
+let params = {}
+let baseUrl
+let myEnv
+
+if (isEnvValid(__ENV.TARGET_ENV)) {
+	myEnv = dotenv.parse(open(`../../../.env.${__ENV.TARGET_ENV}.local`))
+	baseUrl = services[`${__ENV.TARGET_ENV}_issuer_internal`].baseUrl
+
+	/*
+	options.tlsAuth = [
+		{
+			domains: [baseUrl],
+			cert: open(`../../../certs/${myEnv.MAUTH_CERT_NAME}`),
+			key: open(`../../../certs/${myEnv.MAUTH_PRIVATE_KEY_NAME}`),
+		},
+	]
+	*/
+
+	params.headers = {
+		'Ocp-Apim-Subscription-Key': myEnv.APIM_SK,
+		'Ocp-Apim-Trace': 'true',
+        'Content-Type': 'application/json'
+	}
+}
+
+// In performance tests we shall use abort() to prevent the execution
+// of the default function, otherwise the VUs will be spawned
+if (!isTestEnabledOnEnv(__ENV.TARGET_ENV, REGISTERED_ENVS)) {
+	console.log('Test not enabled for target env')
+	exec.test.abort()
+}
+
+
+export default () => {
+	group('FA HB Customer API (internal)', () => {
+
+		const body = {
+			id: randomFiscalCode()
+		}
+
+		group('Should create an FA CUSTOMER', () =>
+			assert(putFaCustomerInternal(baseUrl, params, body), [
+				statusOk(),
+			])
+		)
+		group('Should get an FA CUSTOMER', () =>
+			assert(getFaCustomerInternal(baseUrl, params, body.id), [
+				statusOk(),
+			])
+		)
+	})
+}


### PR DESCRIPTION
This pull request adds a load test that allows to reach the "faHbCustomer" service directly from inside, this is needed for scientific purposes related to the collaboration project with the University of Messina.

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->


- [x] Test case
- [ ] Test suite

### Affected environment

- [x] Development (DEV)
- [x] User Acceptance / Third Part Integration (UAT)
- [ ] Production (PROD)

### Test type

- [ ] End to end
- [x] Performance
- [ ] Smoke test

### Type of changes

- [x] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance