### PR TITLE
[CEN-1464] Add FA EXT Merchant API load tests

### DIFF
--- a/test/common/api/faExtMerchant.js
+++ b/test/common/api/faExtMerchant.js
@@ -1,0 +1,26 @@
+import http from 'k6/http'
+import { URL } from 'https://jslib.k6.io/url/1.0.0/index.js'
+
+const API_PREFIX = '/fa/ext/merchant'
+
+export function getContractListByShopId(baseUrl, params, shopId, registerCode) {
+    const myParams = Object.assign({}, params)
+    const url = new URL(`${baseUrl}${API_PREFIX}/shop/${shopId}/contract/list`)
+    if (registerCode) {
+        url.searchParams.append('registerCode', registerCode)
+    }
+    const res = http.get(url.toString(), myParams)
+    __ENV.REQ_DUMP === undefined || console.log(JSON.stringify(res, null, 2))
+    return res
+}
+
+export function putMerchantByOther(baseUrl, params, body) {
+    const myParams = Object.assign({}, params)
+    const res = http.put(
+        `${baseUrl}${API_PREFIX}/other`,
+        JSON.stringify(body),
+        myParams
+    )
+    __ENV.REQ_DUMP === undefined || console.log(JSON.stringify(res, null, 2))
+    return res
+}

--- a/test/common/utils.js
+++ b/test/common/utils.js
@@ -1,4 +1,7 @@
-import { randomString } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js'
+import {
+    randomString,
+    randomIntBetween,
+} from 'https://jslib.k6.io/k6-utils/1.1.0/index.js'
 
 export function randomFiscalCode() {
     '^([A-Za-z]{6}[0-9lmnpqrstuvLMNPQRSTUV]{2}[abcdehlmprstABCDEHLMPRST]{1}[0-9lmnpqrstuvLMNPQRSTUV]{2}[A-Za-z]{1}[0-9lmnpqrstuvLMNPQRSTUV]{3}[A-Za-z]{1})$'
@@ -22,6 +25,10 @@ export function randomDate(start, end) {
     return new Date(
         start.getTime() + Math.random() * (end.getTime() - start.getTime())
     )
+}
+
+export function randomVatNumber() {
+    return randomIntBetween(10000000000, 99999999999)
 }
 
 function getFiscalCodeMonth(month) {

--- a/test/performance/faExtMerchant.js
+++ b/test/performance/faExtMerchant.js
@@ -1,0 +1,120 @@
+import { group } from 'k6'
+import exec from 'k6/execution'
+import {
+    getContractListByShopId,
+    putMerchantByOther,
+} from '../common/api/faExtMerchant.js'
+import { assert, statusOk } from '../common/assertions.js'
+import { isEnvValid, isTestEnabledOnEnv, DEV, UAT } from '../common/envs.js'
+import dotenv from 'k6/x/dotenv'
+import { randomVatNumber } from '../common/utils.js'
+
+const REGISTERED_ENVS = [DEV, UAT]
+
+const services = JSON.parse(open('../../services/environments.json'))
+
+export let options = {
+    scenarios: {
+        constant_request_rate: {
+            executor: 'constant-arrival-rate',
+            rate: 1,
+            timeUnit: '1s',
+            duration: '1m',
+            preAllocatedVUs: 100,
+            maxVUs: 10000,
+        },
+    },
+    summaryTrendStats: [
+        'med',
+        'avg',
+        'min',
+        'max',
+        'p(10)',
+        'p(20)',
+        'p(30)',
+        'p(40)',
+        'p(50)',
+        'p(60)',
+        'p(70)',
+        'p(80)',
+        'p(90)',
+    ],
+}
+
+let params = {}
+let baseUrl
+let myEnv
+
+if (isEnvValid(__ENV.TARGET_ENV)) {
+    myEnv = dotenv.parse(open(`../../.env.${__ENV.TARGET_ENV}.local`))
+    baseUrl = services[`${__ENV.TARGET_ENV}_issuer`].baseUrl
+
+    options.tlsAuth = [
+        {
+            domains: [baseUrl],
+            cert: open(`../../certs/${myEnv.MAUTH_CERT_NAME}`),
+            key: open(`../../certs/${myEnv.MAUTH_PRIVATE_KEY_NAME}`),
+        },
+    ]
+
+    params.headers = {
+        'Ocp-Apim-Subscription-Key': myEnv.APIM_SK,
+        'Ocp-Apim-Trace': 'true',
+        'Content-Type': 'application/json',
+    }
+}
+
+// In performance tests we shall use abort() to prevent the execution
+// of the default function, otherwise the VUs will be spawned
+if (!isTestEnabledOnEnv(__ENV.TARGET_ENV, REGISTERED_ENVS)) {
+    console.log('Test not enabled for target env')
+    exec.test.abort()
+}
+
+function createBody() {
+    return {
+        vatNumber: randomVatNumber(),
+        companyName: 'Company test',
+        registerAuth: 'register_4',
+        registerCode: '00004',
+        shops: [
+            {
+                callId: 1,
+                companyAddress: 'Test address 1',
+                companyName: 'Test name 1',
+                contactEmail: 'test.1@test.test',
+                contactName: 'Contact name 1',
+                contactSurname: 'Contact surname 1',
+                contactTel1: '+39420000000001',
+                providerId: 1,
+            },
+        ],
+    }
+}
+
+function extractShopIdFromResponse(response) {
+    if (response.status === 200 && response.body && response.body !== '') {
+        const resBody = JSON.parse(response.body)
+        if (resBody.shops && resBody.shops.length > 0) {
+            return resBody.shops[0].shopId
+        }
+    }
+    return ''
+}
+
+export default () => {
+    group('FA EXT Merchant API', () => {
+        const body = createBody()
+        let shopId = ''
+        group('Should put a merchant', () => {
+            const res = putMerchantByOther(baseUrl, params, body)
+            assert(res, [statusOk()])
+            shopId = extractShopIdFromResponse(res)
+        })
+        group('Should get merchant contract list', () =>
+            assert(getContractListByShopId(baseUrl, params, shopId), [
+                statusOk(),
+            ])
+        )
+    })
+}

--- a/test/performance/faExtMerchant.js
+++ b/test/performance/faExtMerchant.js
@@ -17,7 +17,7 @@ export let options = {
     scenarios: {
         constant_request_rate: {
             executor: 'constant-arrival-rate',
-            rate: 1,
+            rate: 50,
             timeUnit: '1s',
             duration: '1m',
             preAllocatedVUs: 100,


### PR DESCRIPTION
This PR adds load tests for FA EXT Merchant API, they are compliant with the requirements from the collaborative project with University of Messina.

### List of changes

- Add functions to send a GET and a PUT request to FA EXT Merchant API.
- Add load test that leverage the functions mentioned in the previous point.
- Add an utils function to generate random VAT number (it may be useful for new tests in future).

### Motivation and context
The load test that is added in this PR, is necessary to be able to inject some load into the service in question, so we can see its behavior while it is under stress, this is to understand how to properly scale the microservices that stand behind the API in question.
<!--- Why is this change required? What problem does it solve? -->

### Aggregation level
<!--- Did you write a single reusable test case, or a full test suite?  -->


- [ ] Test case
- [X] Test suite

### Affected environment

- [x] Development (DEV)
- [x] User Acceptance / Third Part Integration (UAT)
- [ ] Production (PROD)

### Test type

- [ ] End to end
- [x] Performance
- [ ] Smoke test

### Type of changes

- [x] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance