### PR TITLE
[CEN-1520] Add load tests for FA Register Transaction API

### DIFF
--- a/test/common/api/faRegisterTransaction.js
+++ b/test/common/api/faRegisterTransaction.js
@@ -1,0 +1,24 @@
+import http from 'k6/http'
+
+const API_PREFIX = '/fa/transaction'
+
+export function getPosTransaction(baseUrl, params, id) {
+    const myParams = Object.assign({}, params)
+    const res = http.get(
+        `${baseUrl}${API_PREFIX}/pos/invoice/request/${id}`,
+        myParams
+    )
+    __ENV.REQ_DUMP === undefined || console.log(JSON.stringify(res, null, 2))
+    return res
+}
+
+export function createPosTransaction(baseUrl, params, body) {
+    const myParams = Object.assign({}, params)
+    const res = http.post(
+        `${baseUrl}${API_PREFIX}/pos/invoice/request`,
+        JSON.stringify(body),
+        myParams
+    )
+    __ENV.REQ_DUMP === undefined || console.log(JSON.stringify(res, null, 2))
+    return res
+}

--- a/test/performance/faRegisterTransaction.js
+++ b/test/performance/faRegisterTransaction.js
@@ -1,0 +1,106 @@
+import { group } from 'k6'
+import exec from 'k6/execution'
+import {
+    getPosTransaction,
+    createPosTransaction,
+} from '../common/api/faRegisterTransaction.js'
+import { assert, statusOk } from '../common/assertions.js'
+import { isEnvValid, isTestEnabledOnEnv, DEV, UAT } from '../common/envs.js'
+import dotenv from 'k6/x/dotenv'
+import { randomString } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js'
+
+const REGISTERED_ENVS = [DEV, UAT]
+
+const services = JSON.parse(open('../../services/environments.json'))
+
+export let options = {
+    scenarios: {
+        constant_request_rate: {
+            executor: 'constant-arrival-rate',
+            rate: 100,
+            timeUnit: '1s',
+            duration: '1m',
+            preAllocatedVUs: 100,
+            maxVUs: 10000,
+        },
+    },
+    summaryTrendStats: [
+        'med',
+        'avg',
+        'min',
+        'max',
+        'p(10)',
+        'p(20)',
+        'p(30)',
+        'p(40)',
+        'p(50)',
+        'p(60)',
+        'p(70)',
+        'p(80)',
+        'p(90)',
+    ],
+}
+
+let params = {}
+let baseUrl
+let myEnv
+
+if (isEnvValid(__ENV.TARGET_ENV)) {
+    myEnv = dotenv.parse(open(`../../.env.${__ENV.TARGET_ENV}.local`))
+    baseUrl = services[`${__ENV.TARGET_ENV}_issuer`].baseUrl
+
+    options.tlsAuth = [
+        {
+            domains: [baseUrl],
+            cert: open(`../../certs/${myEnv.MAUTH_CERT_NAME}`),
+            key: open(`../../certs/${myEnv.MAUTH_PRIVATE_KEY_NAME}`),
+        },
+    ]
+
+    params.headers = {
+        'Ocp-Apim-Subscription-Key': myEnv.APIM_SK,
+        'Ocp-Apim-Trace': 'true',
+        'Content-Type': 'application/json',
+    }
+}
+
+// In performance tests we shall use abort() to prevent the execution
+// of the default function, otherwise the VUs will be spawned
+if (!isTestEnabledOnEnv(__ENV.TARGET_ENV, REGISTERED_ENVS)) {
+    console.log('Test not enabled for target env')
+    exec.test.abort()
+}
+
+function extractTransactionId(response) {
+    if (response.status === 200 && response.body) {
+        const respBody = JSON.parse(response.body)
+        return respBody.id
+    }
+    return ''
+}
+
+export default () => {
+    group('FA REGISTER Transaction API', () => {
+        let transactionId = ''
+        const body = {
+            amount: 43,
+            binCard: '11223344',
+            authCode: randomString(11),
+            vatNumber: '04533641009',
+            posType: 'ASSERVED_POS',
+            terminalId: '11111111',
+            trxDate: '1983-05-02T00:00:00.000Z',
+            contractId: '3',
+        }
+        group('Should create a Transaction', () => {
+            const res = createPosTransaction(baseUrl, params, body)
+            assert(res, [statusOk()])
+            transactionId = extractTransactionId(res)
+        })
+        group('Should get a Transaction', () =>
+            assert(getPosTransaction(baseUrl, params, transactionId), [
+                statusOk(),
+            ])
+        )
+    })
+}


### PR DESCRIPTION
This PR adds load tests for FA REGISTER Transaction API, they are in accordance with what is required (for scientific purposes) by the collaboration project with the University of Messina.

### List of changes
- Add functions to create a pos transaction and to get a pos transaction

### Motivation and context
This load test is to see how the microservices that stand behind the FA REGISTER Transaction API behave when they are stressed in order to scale them in the best possible way.

### Aggregation level



- [ ] Test case
- [x] Test suite

### Affected environment

- [x] Development (DEV)
- [x] User Acceptance / Third Part Integration (UAT)
- [ ] Production (PROD)

### Test type

- [ ] End to end
- [x] Performance
- [ ] Smoke test

### Type of changes

- [x] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance
