### PR TITLE
[CEN-1598] Add constant load options json file

### DIFF
--- a/options/constant_load.json
+++ b/options/constant_load.json
@@ -1,0 +1,27 @@
+{
+    "scenarios": {
+        "constant_request_rate": {
+           "executor": "constant-arrival-rate",
+            "rate": 100,
+            "timeUnit": "1s",
+            "duration": "1m",
+            "preAllocatedVUs": 100,
+            "maxVUs": 10000
+        }
+    },
+    "summaryTrendStats": [
+        "med",
+        "avg",
+        "min",
+        "max",
+        "p(10)",
+        "p(20)",
+        "p(30)",
+        "p(40)",
+        "p(50)",
+        "p(60)",
+        "p(70)",
+        "p(80)",
+        "p(90)"
+    ]
+}

--- a/test/performance/faExtMerchant.js
+++ b/test/performance/faExtMerchant.js
@@ -13,33 +13,7 @@ const REGISTERED_ENVS = [DEV, UAT]
 
 const services = JSON.parse(open('../../services/environments.json'))
 
-export let options = {
-    scenarios: {
-        constant_request_rate: {
-            executor: 'constant-arrival-rate',
-            rate: 50,
-            timeUnit: '1s',
-            duration: '1m',
-            preAllocatedVUs: 100,
-            maxVUs: 10000,
-        },
-    },
-    summaryTrendStats: [
-        'med',
-        'avg',
-        'min',
-        'max',
-        'p(10)',
-        'p(20)',
-        'p(30)',
-        'p(40)',
-        'p(50)',
-        'p(60)',
-        'p(70)',
-        'p(80)',
-        'p(90)',
-    ],
-}
+export let options = JSON.parse(open('../../options/constant_load.json'))
 
 let params = {}
 let baseUrl

--- a/test/performance/faExtProvider.js
+++ b/test/performance/faExtProvider.js
@@ -9,33 +9,7 @@ const REGISTERED_ENVS = [DEV, UAT]
 
 const services = JSON.parse(open('../../services/environments.json'))
 
-export let options = {
-    scenarios: {
-        constant_request_rate: {
-            executor: 'constant-arrival-rate',
-            rate: 100,
-            timeUnit: '1s',
-            duration: '1m',
-            preAllocatedVUs: 100,
-            maxVUs: 10000,
-        },
-    },
-    summaryTrendStats: [
-        'med',
-        'avg',
-        'min',
-        'max',
-        'p(10)',
-        'p(20)',
-        'p(30)',
-        'p(40)',
-        'p(50)',
-        'p(60)',
-        'p(70)',
-        'p(80)',
-        'p(90)',
-    ],
-}
+export let options = JSON.parse(open('../../options/constant_load.json'))
 
 let params = {}
 let baseUrl

--- a/test/performance/faHbCustomer.js
+++ b/test/performance/faHbCustomer.js
@@ -10,33 +10,7 @@ const REGISTERED_ENVS = [DEV, UAT]
 
 const services = JSON.parse(open('../../services/environments.json'))
 
-export let options = {
-    scenarios: {
-        constant_request_rate: {
-            executor: 'constant-arrival-rate',
-            rate: 100,
-            timeUnit: '1s',
-            duration: '1m',
-            preAllocatedVUs: 100,
-            maxVUs: 10000,
-        },
-    },
-    summaryTrendStats: [
-        'med',
-        'avg',
-        'min',
-        'max',
-        'p(10)',
-        'p(20)',
-        'p(30)',
-        'p(40)',
-        'p(50)',
-        'p(60)',
-        'p(70)',
-        'p(80)',
-        'p(90)',
-    ],
-}
+export let options = JSON.parse(open('../../options/constant_load.json'))
 
 let params = {}
 let baseUrl

--- a/test/performance/faHbPaymentInstruments.js
+++ b/test/performance/faHbPaymentInstruments.js
@@ -16,33 +16,7 @@ const REGISTERED_ENVS = [DEV, UAT]
 
 const services = JSON.parse(open('../../services/environments.json'))
 
-export let options = {
-    scenarios: {
-        constant_request_rate: {
-            executor: 'constant-arrival-rate',
-            rate: 50,
-            timeUnit: '1s',
-            duration: '1m',
-            preAllocatedVUs: 100,
-            maxVUs: 10000,
-        },
-    },
-    summaryTrendStats: [
-        'med',
-        'avg',
-        'min',
-        'max',
-        'p(10)',
-        'p(20)',
-        'p(30)',
-        'p(40)',
-        'p(50)',
-        'p(60)',
-        'p(70)',
-        'p(80)',
-        'p(90)',
-    ],
-}
+export let options = JSON.parse(open('../../options/constant_load.json'))
 
 let params = {}
 let baseUrl

--- a/test/performance/faIoTransaction.js
+++ b/test/performance/faIoTransaction.js
@@ -11,33 +11,7 @@ const REGISTERED_ENVS = [DEV, UAT]
 
 const services = JSON.parse(open('../../services/environments.json'))
 
-export let options = {
-    scenarios: {
-        constant_request_rate: {
-            executor: 'constant-arrival-rate',
-            rate: 100,
-            timeUnit: '1s',
-            duration: '1m',
-            preAllocatedVUs: 100,
-            maxVUs: 10000,
-        },
-    },
-    summaryTrendStats: [
-        'med',
-        'avg',
-        'min',
-        'max',
-        'p(10)',
-        'p(20)',
-        'p(30)',
-        'p(40)',
-        'p(50)',
-        'p(60)',
-        'p(70)',
-        'p(80)',
-        'p(90)',
-    ],
-}
+export let options = JSON.parse(open('../../options/constant_load.json'))
 
 let baseUrl
 let myEnv

--- a/test/performance/faRegisterTransaction.js
+++ b/test/performance/faRegisterTransaction.js
@@ -13,33 +13,7 @@ const REGISTERED_ENVS = [DEV, UAT]
 
 const services = JSON.parse(open('../../services/environments.json'))
 
-export let options = {
-    scenarios: {
-        constant_request_rate: {
-            executor: 'constant-arrival-rate',
-            rate: 100,
-            timeUnit: '1s',
-            duration: '1m',
-            preAllocatedVUs: 100,
-            maxVUs: 10000,
-        },
-    },
-    summaryTrendStats: [
-        'med',
-        'avg',
-        'min',
-        'max',
-        'p(10)',
-        'p(20)',
-        'p(30)',
-        'p(40)',
-        'p(50)',
-        'p(60)',
-        'p(70)',
-        'p(80)',
-        'p(90)',
-    ],
-}
+export let options = JSON.parse(open('../../options/constant_load.json'))
 
 let params = {}
 let baseUrl

--- a/test/performance/internal/faHbCustomer.js
+++ b/test/performance/internal/faHbCustomer.js
@@ -13,33 +13,7 @@ const REGISTERED_ENVS = [DEV, UAT]
 
 const services = JSON.parse(open('../../../services/environments.json'))
 
-export let options = {
-    scenarios: {
-        constant_request_rate: {
-            executor: 'constant-arrival-rate',
-            rate: 1,
-            timeUnit: '1s',
-            duration: '1m',
-            preAllocatedVUs: 100,
-            maxVUs: 10000,
-        },
-    },
-    summaryTrendStats: [
-        'med',
-        'avg',
-        'min',
-        'max',
-        'p(10)',
-        'p(20)',
-        'p(30)',
-        'p(40)',
-        'p(50)',
-        'p(60)',
-        'p(70)',
-        'p(80)',
-        'p(90)',
-    ],
-}
+export let options = JSON.parse(open('../../../options/constant_load.json'))
 
 let params = {}
 let baseUrl

--- a/test/performance/internal/faIoTransaction.js
+++ b/test/performance/internal/faIoTransaction.js
@@ -13,33 +13,7 @@ const REGISTERED_ENVS = [DEV, UAT]
 
 const services = JSON.parse(open('../../../services/environments.json'))
 
-export let options = {
-    scenarios: {
-        constant_request_rate: {
-            executor: 'constant-arrival-rate',
-            rate: 100,
-            timeUnit: '1s',
-            duration: '1m',
-            preAllocatedVUs: 100,
-            maxVUs: 10000,
-        },
-    },
-    summaryTrendStats: [
-        'med',
-        'avg',
-        'min',
-        'max',
-        'p(10)',
-        'p(20)',
-        'p(30)',
-        'p(40)',
-        'p(50)',
-        'p(60)',
-        'p(70)',
-        'p(80)',
-        'p(90)',
-    ],
-}
+export let options = JSON.parse(open('../../../options/constant_load.json'))
 
 let baseUrl
 let myEnv


### PR DESCRIPTION
This PR adds a JSON file containing k6 options to do load tests with constant rate to be imported into the different test files.
### List of changes
- Add json file with k6 options and import it into FA load test files.
<!--- Describe your changes in detail -->

### Motivation and context
This change aims to make the code more clean and easily editable in future.
<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->


- [ ] Test case
- [x] Test suite

### Affected environment

- [x] Development (DEV)
- [x] User Acceptance / Third Part Integration (UAT)
- [ ] Production (PROD)

### Test type

- [ ] End to end
- [x] Performance
- [ ] Smoke test

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Other information

Before merging this pull request, it is necessary to merge the ones already open related to the FA API load tests, so that this change can be added in the other tests too