### PR TITLE
[CEN-1603] Add load test for fa mock RTD send transaction

### DIFF
--- a/test/common/api/faMock.js
+++ b/test/common/api/faMock.js
@@ -1,0 +1,15 @@
+import http from 'k6/http'
+
+const API_PREFIX = '/fa/mock'
+
+export function rtdSendTransaction(baseUrl, params, body) {
+    params.headers.product = 'issuer-api-product'
+    const myParams = Object.assign({}, params)
+    const res = http.post(
+        `${baseUrl}${API_PREFIX}/transaction/rtd/send`,
+        JSON.stringify(body),
+        myParams
+    )
+    __ENV.REQ_DUMP === undefined || console.log(JSON.stringify(res, null, 2))
+    return res
+}

--- a/test/e2e/cdcSogeiTranscodeToken.js
+++ b/test/e2e/cdcSogeiTranscodeToken.js
@@ -18,7 +18,10 @@ if (isEnvValid(__ENV.TARGET_ENV)) {
 }
 
 export function setup() {
-    const authToken = loginFullUrl(`${baseUrl}/bpd/pagopa/api/v1/login`, myEnv.FISCAL_CODE_EXISTING)
+    const authToken = loginFullUrl(
+        `${baseUrl}/bpd/pagopa/api/v1/login`,
+        myEnv.FISCAL_CODE_EXISTING
+    )
     return {
         headers: {
             Authorization: `Bearer ${authToken}`,

--- a/test/performance/faMockRtdSendTransaction.js
+++ b/test/performance/faMockRtdSendTransaction.js
@@ -1,0 +1,68 @@
+import { group } from 'k6'
+import exec from 'k6/execution'
+import { rtdSendTransaction } from '../common/api/faMock.js'
+import { assert, statusOk } from '../common/assertions.js'
+import { isEnvValid, isTestEnabledOnEnv, DEV, UAT } from '../common/envs.js'
+import dotenv from 'k6/x/dotenv'
+
+const REGISTERED_ENVS = [DEV, UAT]
+
+const services = JSON.parse(open('../../services/environments.json'))
+
+export let options = JSON.parse(open('../../options/constant_load.json'))
+
+let params = {}
+let baseUrl
+let myEnv
+
+if (isEnvValid(__ENV.TARGET_ENV)) {
+    myEnv = dotenv.parse(open(`../../.env.${__ENV.TARGET_ENV}.local`))
+    baseUrl = services[`${__ENV.TARGET_ENV}_issuer`].baseUrl
+
+    options.tlsAuth = [
+        {
+            domains: [baseUrl],
+            cert: open(`../../certs/${myEnv.MAUTH_CERT_NAME}`),
+            key: open(`../../certs/${myEnv.MAUTH_PRIVATE_KEY_NAME}`),
+        },
+    ]
+
+    params.headers = {
+        'Ocp-Apim-Subscription-Key': myEnv.APIM_SK,
+        'Ocp-Apim-Trace': 'true',
+        'Content-Type': 'application/json',
+    }
+}
+
+// In performance tests we shall use abort() to prevent the execution
+// of the default function, otherwise the VUs will be spawned
+if (!isTestEnabledOnEnv(__ENV.TARGET_ENV, REGISTERED_ENVS)) {
+    console.log('Test not enabled for target env')
+    exec.test.abort()
+}
+
+export default () => {
+    group('FA Mock Transaction API', () => {
+        const body = {
+            acquirerCode: '4964835',
+            acquirerId: '650684654635',
+            amount: 43,
+            amountCurrency: '978',
+            bin: '870965',
+            circuitType: '02',
+            correlationId: '6840974651304',
+            hpan: 'df0765566e279292d7079ed995c46e8d12267a2a42baa50b439de4fb2f2e32a0',
+            idTrxAcquirer: '6849018651351',
+            idTrxIssuer: '68409489648604165',
+            mcc: '7011',
+            merchantId: '1',
+            operationType: '00',
+            terminalId: '40654165',
+            trxDate: '1983-05-02T00:00:00.000Z',
+        }
+        group('Should send a RTD Transaction', () => {
+            const res = rtdSendTransaction(baseUrl, params, body)
+            assert(res, [statusOk()])
+        })
+    })
+}


### PR DESCRIPTION
In order to get a more complete overview of the load on CSTAR's infrastructure, this PR adds a load test for the endpoint "FA Mock RTD Send Transaction"

### List of changes

- Add a load test for "FA Mock RTD Send Transaction"

### Motivation and context
This change helps both to have more load testing on the CSTAR infrastructure, but also to have an easy way to submit RTD transactions.
### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->


- [ ] Test case
- [x] Test suite

### Affected environment

- [x] Development (DEV)
- [x] User Acceptance / Third Part Integration (UAT)
- [ ] Production (PROD)

### Test type

- [ ] End to end
- [x] Performance
- [ ] Smoke test

### Type of changes

- [x] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [ ] Success
- [x] Failure
- [ ] Poor performance
- [ ] Good performance

### Other information
At the moment the test doesn't work, I think you have to pass correct data to the request body