### PR TITLE
[CDC-29] Test suite which uses a true BPD token

### DIFF
--- a/env.local.sample
+++ b/env.local.sample
@@ -6,6 +6,7 @@ MAUTH_PRIVATE_KEY_NAME=[name of the mauth rivate key file in certs directory ]
 PAN_OK=[pan of a card enrolled]
 ENCRYPTED_PAN=[pgp encrypted pan]
 FISCAL_CODE_EXISTING=[fiscal code]
+BPD_TOKEN=[BPD TOKEN]
 
 # Max content length for /hashed-pans API in bytes (0 means no max length)
 RTD_HASHPAN_MAX_CONTENT_LENGTH=0

--- a/test/e2e/cdcRequestWithIOToken.js
+++ b/test/e2e/cdcRequestWithIOToken.js
@@ -1,0 +1,153 @@
+import { group } from 'k6'
+import {
+    happyCase,
+    happyCaseWithoutIseeDate,
+    partialHappyCase,
+    twoStepHappyCase,
+    postIdempotence,
+    getIdempotence,
+    failureCaseWithEmptyYearList,
+    failureWithWrongYear,
+    failureWithYearListTooLong,
+    failureWithGoodYearInWrongFormat,
+    failureCaseWithNoInput,
+} from '../common/api/cdcIoRequest.js'
+import { loginFullUrl } from '../common/api/bpdIoLogin.js'
+import {
+    assert,
+    bodyJsonReduceArray,
+    statusOk,
+    statusBadFormat,
+    bodyJsonSelectorValue,
+    idempotence,
+} from '../common/assertions.js'
+import { isEnvValid, isTestEnabledOnEnv, PROD } from '../common/envs.js'
+import dotenv from 'k6/x/dotenv'
+import { randomFiscalCode } from '../common/utils.js'
+
+const REGISTERED_ENVS = [PROD]
+
+const services = JSON.parse(open('../../services/environments.json'))
+let baseUrl
+let myEnv
+
+if (isEnvValid(__ENV.TARGET_ENV)) {
+    myEnv = dotenv.parse(open(`../../.env.${__ENV.TARGET_ENV}.local`))
+    baseUrl = services[`${__ENV.TARGET_ENV}_io`].baseUrl
+}
+
+function auth() {
+    return {
+        headers: {
+            Authorization: `Bearer ${myEnv.BPD_TOKEN}`,
+            'Ocp-Apim-Subscription-Key': `${myEnv.APIM_SK};product=app-io-product`,
+            'Ocp-Apim-Trace': 'true',
+        },
+    }
+}
+
+export default () => {
+    if (
+        !isEnvValid(__ENV.TARGET_ENV) ||
+        !isTestEnabledOnEnv(__ENV.TARGET_ENV, REGISTERED_ENVS)
+    ) {
+        return
+    }
+    group('Should request CdC', () => {
+        group('When the post contains all years returned by get', () => {
+            const esitoOkReducer = (prv, cur) =>
+                prv && ( ['OK', 'CIT_REGISTRATO'].includes(
+                  cur.esitoRichiesta)
+              )
+            assert(happyCase(baseUrl, auth()), [
+                statusOk(),
+                bodyJsonReduceArray(
+                    'listaEsitoRichiestaPerAnno',
+                    esitoOkReducer,
+                    true,
+                    true
+                ),
+            ])
+        })
+        
+    })
+
+    group('POST Request should be', () => {
+        group('Idempotent', () => {
+            assert(postIdempotence(baseUrl, auth()), [
+                idempotence(),
+            ])
+        })
+    })
+
+    group('GET Request should be', () => {
+        group('Idempotent', () => {
+            assert(getIdempotence(baseUrl, auth()), [
+                idempotence(),
+            ])
+        })
+    })
+
+    group('Should not Request CdC', () => {
+        group('When the list of years is empty', () => {
+            assert(
+                failureCaseWithEmptyYearList(baseUrl, auth()),
+                [
+                    statusBadFormat(),
+                    bodyJsonSelectorValue('status', 'LISTA_ANNI_VUOTA'),
+                ]
+            )
+        })
+        group(
+            'When the customer selects only a subset of admissible years plus a wrong year',
+            () => {
+                assert(
+                    failureWithWrongYear(baseUrl, auth()),
+                    [
+                        statusBadFormat(),
+                        bodyJsonSelectorValue('status', 'FORMATO_ANNI_ERRATO'),
+                    ]
+                )
+            }
+        )
+        group(
+            'When the customer selects a list of years which is longer than expected',
+            () => {
+                assert(
+                    failureWithYearListTooLong(
+                        baseUrl,
+                        auth()
+                    ),
+                    [
+                        statusBadFormat(),
+                        bodyJsonSelectorValue(
+                            'status',
+                            'INPUT_SUPERIORE_AL_CONSENTITO'
+                        ),
+                    ]
+                )
+            }
+        )
+        group(
+            'When the customer send a year in a wrong format (e.g. as a date 2021/01/01)',
+            () => {
+                assert(
+                    failureWithGoodYearInWrongFormat(
+                        baseUrl,
+                        auth()
+                    ),
+                    [
+                        statusBadFormat(),
+                        bodyJsonSelectorValue('status', 'FORMATO_ANNI_ERRATO'),
+                    ]
+                )
+            }
+        )
+        group('When the customer sends no input', () => {
+            assert(failureCaseWithNoInput(baseUrl, auth()), [
+                statusBadFormat(),
+                bodyJsonSelectorValue('status', 'NO_INPUT'),
+            ])
+        })
+    })
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add a test suite which uses the bpd token in bearer authorization scheme

### List of changes

<!--- Describe your changes in detail -->
- new test suite

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This suite is needed to test in production with a real IO account

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->


- [ ] Test case
- [x] Test suite

### Affected environment

- [ ] Development (DEV)
- [ ] User Acceptance / Third Part Integration (UAT)
- [x] Production (PROD)

### Test type

- [x] End to end
- [ ] Performance
- [ ] Smoke test

### Type of changes

- [x] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->