### PR TITLE
[RTD-446] Add test e2e for abi to fiscal code map api

### DIFF
--- a/test/e2e/taeFakeAbiToFiscalCodeMap.js
+++ b/test/e2e/taeFakeAbiToFiscalCodeMap.js
@@ -35,7 +35,10 @@ export default () => {
     group('TAE AbiToFiscalCode API', () => {
         group('Should retrieve conversion map', () =>
             assert(getAbiToFiscalCodesMap(baseUrl, params), [statusOk(),
-            bodyJsonSelectorValue('STPAY', 'LU30726739')])
+            bodyJsonSelectorValue('STPAY', 'LU30726739'),
+            bodyJsonSelectorValue('BPAY1', '04949971008'),
+            bodyJsonSelectorValue('SUMUP', 'IE9813461A'),
+            bodyJsonSelectorValue('ICARD', 'BG175325806')])
         )
     })
 }

--- a/test/e2e/taeFakeAbiToFiscalCodeMap.js
+++ b/test/e2e/taeFakeAbiToFiscalCodeMap.js
@@ -1,0 +1,41 @@
+import { group } from 'k6'
+import { assert, statusOk, bodyJsonSelectorValue } from '../common/assertions.js'
+import { isEnvValid, isTestEnabledOnEnv, DEV } from '../common/envs.js'
+import dotenv from 'k6/x/dotenv'
+import { randomFiscalCode } from '../common/utils.js'
+import { getAbiToFiscalCodesMap } from '../common/api/taeAbiToFiscalCodes.js'
+
+
+const REGISTERED_ENVS = [DEV]
+
+const services = JSON.parse(open('../../services/environments.json'))
+let params = {}
+let options = {}
+let baseUrl
+let myEnv
+
+if (isEnvValid(__ENV.TARGET_ENV)) {
+    myEnv = dotenv.parse(open(`../../.env.${__ENV.TARGET_ENV}.local`))
+    baseUrl = services[`${__ENV.TARGET_ENV}_io`].baseUrl
+
+    options.tlsAuth = [
+        {
+            domains: [baseUrl],
+            cert: open(`../../certs/${myEnv.MAUTH_CERT_NAME}`),
+            key: open(`../../certs/${myEnv.MAUTH_PRIVATE_KEY_NAME}`),
+        },
+    ]
+
+    params.headers = {
+        'Ocp-Apim-Subscription-Key': myEnv.APIM_RTDPRODUCT_SK,
+    }
+}
+
+export default () => {
+    group('TAE AbiToFiscalCode API', () => {
+        group('Should retrieve conversion map', () =>
+            assert(getAbiToFiscalCodesMap(baseUrl, params), [statusOk(),
+            bodyJsonSelectorValue('STPAY', 'LU30726739')])
+        )
+    })
+}

--- a/test/smoke/taeApi.js
+++ b/test/smoke/taeApi.js
@@ -51,8 +51,7 @@ export default () => {
     }
     group('TAE API', () => {
         group('Should retrieve conversion map', () =>
-            assert(getAbiToFiscalCodesMap(baseUrl, params), [statusOk(),
-            bodyJsonSelectorValue('STPAY', 'LU30726739')])
+            assert(getAbiToFiscalCodesMap(baseUrl, params), [statusOk()])
         )
         group('Should retrieve filename list', () => {
             assert(getSenderAdeAckFileNameList(baseUrl, params), [statusOk()])


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add the e2e test for the abi to fiscal code map api.

### List of changes

<!--- Describe your changes in detail -->
- Add test e2e

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
In order to test the endpoint in isolation without running a performance test.

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->


- [X] Test case
- [ ] Test suite

### Affected environment

- [X] Development (DEV)
- [X] User Acceptance / Third Part Integration (UAT)
- [X] Production (PROD)

### Test type

- [X] End to end
- [ ] Performance
- [ ] Smoke test

### Type of changes

- [X] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [X] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->