### PR TITLE
[RTD-1542] move setupenv.js into common directory

### DIFF
--- a/test/common/setupenv.js
+++ b/test/common/setupenv.js
@@ -1,4 +1,4 @@
-import {isEnvValid} from "../common/envs.js";
+import {isEnvValid} from "./envs.js";
 import dotenv from 'k6/x/dotenv'
 
 export function setupEnvironment(environmentsPath) {

--- a/test/smoke/rtdTokenManagerIntegration.js
+++ b/test/smoke/rtdTokenManagerIntegration.js
@@ -1,7 +1,7 @@
 import { group, check } from 'k6'
 import {assert, bodyJsonReduceArray, bodyPgpPublicKey, statusOk} from '../common/assertions.js'
 import RtdTokenManagerApi from "../common/api/rtdTokenManagerApi.js";
-import {setupEnvironment} from "./setupenv.js";
+import {setupEnvironment} from "../common/setupenv.js";
 
 const {env, baseUrl} = setupEnvironment('../../services/environments.json');
 const stubTokenFile = open("stub-files/tokenFile.csv");


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to move the setupenv file from `smoke` to `common` directory. The reason is that `smoke_env.sh` runs all the tests in the smoke directory and fails on the setupenv.

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->


- [ ] Test case
- [ ] Test suite

### Affected environment

- [ ] Development (DEV)
- [ ] User Acceptance / Third Part Integration (UAT)
- [ ] Production (PROD)

### Test type

- [ ] End to end
- [ ] Performance
- [ ] Smoke test

### Type of changes

- [ ] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [X] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->