### PR TITLE
[RTD-1631] add AMAZON acquirer code to FC mapping

### DIFF
--- a/test/e2e/taeFakeAbiToFiscalCodeMap.js
+++ b/test/e2e/taeFakeAbiToFiscalCodeMap.js
@@ -45,6 +45,7 @@ export default () => {
                 bodyJsonSelectorValue('ICARD', 'BG175325806'),
                 bodyJsonSelectorValue('TPAY1', '09771701001'),
                 bodyJsonSelectorValue('AMAZN', '97898850157'),
+                bodyJsonSelectorValue('AMAZON', '97898850157'),
                 bodyJsonSelectorValue('EURON', 'DE182769455'),
                 bodyJsonSelectorValue('UBER1', 'NL858620285B01')
             ])


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add `AMAZON` acquirer code to fiscal code mapping in TAE integration test.
### List of changes
- add new entry to expected JSON.
<!--- Describe your changes in detail -->

### Motivation and context
With this change we can test whether the map returned by the endpoint is updated.
<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->


- [x] Test case
- [ ] Test suite

### Affected environment

- [x] Development (DEV)
- [x] User Acceptance / Third Part Integration (UAT)
- [x] Production (PROD)

### Test type

- [ ] End to end
- [ ] Performance
- [x] Smoke test

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->