### PR TITLE
feat: perVuIteration execution with fixed rate when intermediate step

### DIFF
--- a/pipelines/deploy-pipelines.yml
+++ b/pipelines/deploy-pipelines.yml
@@ -349,6 +349,7 @@ jobs:
                           ${{ if eq(k6Test, parameters.SCRIPT) }}:
                               SCENARIO_TYPE_ENV: ${{ parameters.SCENARIO_TYPE_ENV }}
                               VUS_MAX_ENV: ${{ parameters.VUS_MAX_ENV }}
+                              SCENARIO_PER_VU_RAMPING_SIZE: 'true'
                               SCENARIO_PER_VU_SINGLE_ITERATION_ENV: ${{ parameters.SCENARIO_PER_VU_SINGLE_ITERATION_ENV }}
                               SCENARIO_PER_VU_EXECUTIONS_ENV: ${{ parameters.SCENARIO_PER_VU_EXECUTIONS_ENV }}
                               SCENARIO_DURATION_ENV: ${{ parameters.SCENARIO_DURATION_ENV }}
@@ -358,6 +359,7 @@ jobs:
                           ${{ else }}: # intermediate tests will execute this configuration, which ensure the execution of all test entities
                               SCENARIO_TYPE_ENV: perVuIterations
                               VUS_MAX_ENV: '20'
+                              SCENARIO_PER_VU_RAMPING_SIZE: 'false'
                               SCENARIO_PER_VU_SINGLE_ITERATION_ENV: 'false'
                               SCENARIO_PER_VU_EXECUTIONS_ENV: '1'
                               SCENARIO_DURATION_ENV: '2'

--- a/test/common/dynamicScenarios/envVars.js
+++ b/test/common/dynamicScenarios/envVars.js
@@ -28,6 +28,9 @@ export const CONFIG = {
         TYPES: coalesce(__ENV.SCENARIO_TYPE_ENV, 'ALL').split(','),
 
         perVuIterations: {
+            RAMPING_SIZE:
+                __ENV.SCENARIO_PER_VU_RAMPING_SIZE &&
+                __ENV.SCENARIO_PER_VU_RAMPING_SIZE.toLowerCase() === 'true',
             ONESHOT:
                 __ENV.SCENARIO_PER_VU_SINGLE_ITERATION_ENV &&
                 __ENV.SCENARIO_PER_VU_SINGLE_ITERATION_ENV.toLowerCase() !==

--- a/test/common/dynamicScenarios/scenarios/perVuIterations.js
+++ b/test/common/dynamicScenarios/scenarios/perVuIterations.js
@@ -13,7 +13,9 @@ if (!CONFIG.SCENARIOS.perVuIterations.ONESHOT) {
         //random vus with a maximum number of vus
         const randomVus = Math.min(
             availableEntitiesData,
-            randomIntBetween(1, CONFIG.VIRTUAL_USERS)
+            CONFIG.SCENARIOS.perVuIterations.RAMPING_SIZE
+                ? randomIntBetween(1, CONFIG.VIRTUAL_USERS)
+                : CONFIG.VIRTUAL_USERS
         )
 
         scenarios[`${testEntitiesBasedScenarioPrefix}${counter}`] =


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
intermediate step will run perVuIteration scenario with a fixed size of VU instead of random (ASIS)

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->


- [ ] Test case
- [ ] Test suite

### Affected environment

- [ ] Development (DEV)
- [ ] User Acceptance / Third Part Integration (UAT)
- [ ] Production (PROD)

### Test type

- [ ] End to end
- [ ] Performance
- [ ] Smoke test

### Type of changes

- [ ] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [ ] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->